### PR TITLE
Fix attribution urls in config

### DIFF
--- a/config.json
+++ b/config.json
@@ -11,7 +11,7 @@
             "name": "Luftbilder 2019",
             "url": "https://tiles.codefor.de/berlin-2019/{z}/{x}/{y}.png",
             "options": {
-                "attribution": "<a target=\"blank\" href=\"http://fbinter.stadt-berlin.de/fb/berlin/service.jsp?id=a_luftbild2019_rgb@senstadt&type=FEED\">Digitale farbige Orthophotos 2019 (DOP20RGB)</a>",
+                "attribution": "<a target=\"blank\" href=\"https://fbinter.stadt-berlin.de/fb/index.jsp?loginkey=zoomStart&mapId=k_luftbild2019_rgb@senstadt\">Digitale farbige Orthophotos 2019 (DOP20RGB)</a>",
                 "minZoom": 10,
                 "maxZoom": 20
             }
@@ -20,7 +20,7 @@
             "name": "Luftbilder 2018",
             "url": "https://tiles.codefor.de/berlin-2018/{z}/{x}/{y}.png",
             "options": {
-                "attribution": "<a target=\"blank\" href=\"http://fbinter.stadt-berlin.de/fb/berlin/service.jsp?id=a_luftbild2018_rgb@senstadt&type=FEED\">Digitale farbige Orthophotos 2018 (DOP20RGB)</a>",
+                "attribution": "<a target=\"blank\" href=\"https://fbinter.stadt-berlin.de/fb/index.jsp?loginkey=zoomStart&mapId=k_luftbild2018_rgb@senstadt\">Digitale farbige Orthophotos 2018 (DOP20RGB)</a>",
                 "minZoom": 10,
                 "maxZoom": 20
             }
@@ -29,7 +29,7 @@
             "name": "Luftbilder 2017",
             "url": "https://tiles.codefor.de/berlin-2017/{z}/{x}/{y}.png",
             "options": {
-                "attribution": "<a target=\"blank\" href=\"http://fbinter.stadt-berlin.de/fb/berlin/service.jsp?id=a_luftbild2017_rgb@senstadt&type=FEED\">Digitale farbige Orthophotos 2017 (DOP20RGB)</a>",
+                "attribution": "<a target=\"blank\" href=\"https://fbinter.stadt-berlin.de/fb/index.jsp?loginkey=zoomStart&mapId=k_luftbild2017_rgb@senstadt\">Digitale farbige Orthophotos 2017 (DOP20RGB)</a>",
                 "minZoom": 10,
                 "maxZoom": 20
             }
@@ -38,7 +38,7 @@
             "name": "Luftbilder 2016",
             "url": "https://tiles.codefor.de/berlin-2016/{z}/{x}/{y}.png",
             "options": {
-                "attribution": "<a target=\"blank\" href=\"http://fbinter.stadt-berlin.de/fb/berlin/service.jsp?id=a_luftbild2016_rgb@senstadt&type=FEED\">Geoportal Berlin / Digitale farbige Orthophotos 2016 (DOP20RGB)</a>",
+                "attribution": "<a target=\"blank\" href=\"https://fbinter.stadt-berlin.de/fb/index.jsp?loginkey=zoomStart&mapId=k_luftbild2016_rgb@senstadt\">Geoportal Berlin / Digitale farbige Orthophotos 2016 (DOP20RGB)</a>",
                 "minZoom": 10,
                 "maxZoom": 20
             }
@@ -47,7 +47,7 @@
             "name": "Luftbilder 2015",
             "url": "https://tiles.codefor.de/berlin-2015/{z}/{x}/{y}.png",
             "options": {
-                "attribution": "<a target=\"blank\" href=\"http://fbinter.stadt-berlin.de/fb/berlin/service.jsp?id=a_luftbild2016_rgb@senstadt&type=FEED\">Geoportal Berlin / Digitale farbige Orthophotos 2015 (DOP20RGB)</a>",
+                "attribution": "<a target=\"blank\" href=\"https://fbinter.stadt-berlin.de/fb/index.jsp?loginkey=zoomStart&mapId=k_luftbild2015_rgb@senstadt\">Geoportal Berlin / Digitale farbige Orthophotos 2015 (DOP20RGB)</a>",
                 "minZoom": 10,
                 "maxZoom": 20
             }
@@ -56,7 +56,7 @@
             "name": "Luftbilder 2016 (Infrarot)",
             "url": "https://tiles.codefor.de/berlin-2016i/{z}/{x}/{y}.png",
             "options": {
-                "attribution": "<a target=\"blank\" href=\"http://fbinter.stadt-berlin.de/fb/berlin/service.jsp?id=a_luftbild2016_cir@senstadt&type=FEED\">Geoportal Berlin / Digitale Color-Infrarot-Orthophotos 2016 (DOP20CIR)</a>",
+                "attribution": "<a target=\"blank\" href=\"https://fbinter.stadt-berlin.de/fb/index.jsp?loginkey=zoomStart&mapId=k_luftbild2016_cir@senstadt\">Geoportal Berlin / Digitale Color-Infrarot-Orthophotos 2016 (DOP20CIR)</a>",
                 "minZoom": 10,
                 "maxZoom": 20
             }
@@ -65,7 +65,7 @@
             "name": "Luftbilder 2014",
             "url": "https://tiles.codefor.de/berlin-2014/{z}/{x}/{y}.png",
             "options": {
-                "attribution": "<a target=\"blank\" href=\"http://fbinter.stadt-berlin.de/fb/berlin/service.jsp?id=a_luftbild2014@senstadt&type=FEED\">Geoportal Berlin / Digitale farbige Orthophotos 2014 (DOP20RGB)</a>",
+                "attribution": "<a target=\"blank\" href=\"https://daten.berlin.de/datensaetze/digitale-farbige-orthophotos-2014-dop20rgb-wms-1\">Geoportal Berlin / Digitale farbige Orthophotos 2014 (DOP20RGB)</a>",
                 "minZoom": 10,
                 "maxZoom": 20
             }
@@ -74,7 +74,7 @@
             "name": "Luftbilder 2010",
             "url": "https://tiles.codefor.de/berlin-2010/{z}/{x}/{y}.png",
             "options": {
-                "attribution": "<a target=\"blank\" href=\"http://fbinter.stadt-berlin.de/fb/berlin/service.jsp?id=a_luftbild2010@senstadt&type=FEED\">Geoportal Berlin / Digitale farbige Orthophotos 2010 (DOP20RGB)</a>",
+                "attribution": "<a target=\"blank\" href=\"https://daten.berlin.de/datensaetze/digitale-farbige-orthophotos-2010-dop20rgb-wms-1\">Geoportal Berlin / Digitale farbige Orthophotos 2010 (DOP20RGB)</a>",
                 "minZoom": 10,
                 "maxZoom": 20
             }
@@ -83,7 +83,7 @@
             "name": "Luftbilder 2004",
             "url": "https://tiles.codefor.de/berlin-2004/{z}/{x}/{y}.png",
             "options": {
-                "attribution": "<a target=\"blank\" href=\"http://fbinter.stadt-berlin.de/fb/berlin/service.jsp?id=a_luftbild2004_rgb@senstadt&type=FEED\">Geoportal Berlin / Digitale farbige Orthophotos 2004 (DOP25RGB)</a>",
+                "attribution": "<a target=\"blank\" href=\"https://daten.berlin.de/datensaetze/digitale-farbige-orthophotos-2004-dop25rgb-wms\">Geoportal Berlin / Digitale farbige Orthophotos 2004 (DOP25RGB)</a>",
                 "minZoom": 10,
                 "maxZoom": 20
             }
@@ -211,7 +211,7 @@
             "url": "https://tiles.codefor.de/berlin-gebschaden/{z}/{x}/{y}.png",
             "legend": "https://tiles.codefor.de/meta/legenden/leg_gebschaden.jpg",
             "options": {
-                "attribution": "<a target=\"blank\" href=\"http://fbinter.stadt-berlin.de/fb/berlin/service.jsp?id=a_gebschaden@senstadt&type=FEED\">Geoportal Berlin / Gebäudeschäden 1945</a>",
+                "attribution": "<a target=\"blank\" href=\"https://daten.berlin.de/datensaetze/geb%C3%A4udesch%C3%A4den-1945\">Geoportal Berlin / Gebäudeschäden 1945</a>",
                 "minZoom": 10,
                 "maxZoom": 20
             }
@@ -221,7 +221,7 @@
             "url": "https://tiles.codefor.de/berlin-gebaeudealter/{z}/{x}/{y}.png",
             "legend": "https://tiles.codefor.de/meta/legenden/leg_gebaeudealter.jpg",
             "options": {
-                "attribution": "<a target=\"blank\" href=\"http://fbinter.stadt-berlin.de/fb/berlin/service.jsp?id=a_gebaeudealter@senstadt&type=FEED\">Geoportal Berlin / Gebäudealter 1992/93</a>",
+                "attribution": "<a target=\"blank\" href=\"https://daten.berlin.de/datensaetze/geb%C3%A4udealter-199293-wms\">Geoportal Berlin / Gebäudealter 1992/93</a>",
                 "minZoom": 10,
                 "maxZoom": 20
             }


### PR DESCRIPTION
The attribution now links to a html page. Either the data information page or the fis broker data view. The feed-URL that was used previously was broken for the usecase of browsing it via a web browser.