### PR TITLE
Small cleanup: Remove unused script includes

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,9 +9,6 @@
         <link rel="stylesheet" href="https://unpkg.com/leaflet@1.3.1/dist/leaflet.css" integrity="sha512-Rksm5RenBEKSKFjgI3a41vrjkw4EVPlJ3+OiI65vTjIdo9brlAacEuKOiQ5OFh7cOI1bkDwLqdLw3Zg0cRJAAQ==" crossorigin=""/>
         <script src="https://unpkg.com/leaflet@1.3.1/dist/leaflet.js" integrity="sha512-/Nsx9X4HebavoBvEBuyp3I7od5tA0UzAxs+j83KgC8PU0kgB4XiK4Lfe4y4cgBtaRJQEIFCW+oC506aPT2L1zw==" crossorigin=""></script>
 
-        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/noUiSlider/11.1.0/nouislider.css" integrity="sha256-f3IxuJZ1fdcmPUnncothqSwf/56zbOXTfd+tZes4OxQ=" crossorigin="anonymous" />
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/noUiSlider/11.1.0/nouislider.min.js" integrity="sha256-IB524Svhneql+nv1wQV7OKsccHNhx8OvsGmbF6WCaM0=" crossorigin="anonymous"></script>
-
         <link rel="stylesheet" href="style.css" />
         <script src="app.js"></script>
     </head>


### PR DESCRIPTION
I am pretty sure those includes are only used for https://berlin.codefor.de/luftbilder/, not for this map.